### PR TITLE
change type when reading the diasend xls to get past  error

### DIFF
--- a/lib/xls.js
+++ b/lib/xls.js
@@ -11,7 +11,7 @@ function xls (opts) {
   var worker = es.through(workbooks);
   function incoming (err, results) {
     var all = Buffer.concat(results);
-    var wb = X.read(all, {type: 'binary'});
+    var wb = X.read(all, {type: 'buffer'});  //setting the type to binary or base64 cause the conversion to fail, buffer made it work
     worker.write(wb);
   }
 


### PR DESCRIPTION
With this change I'm able to import from diasend and view both the diasend and dexcom data in my locally running blip instance.

Before making the change I got this error:

> /Users/jcalabre/Development/tidepool/jellyfish/node_modules/tidepool-animas-diasend-data/node_modules/xlsjs/xls.js:5538
>       case 'binary': return f.charCodeAt(0);
>                               ^
> TypeError: Object ��ࡱ�

The encoding mess after Object was printed to the console
